### PR TITLE
Accidently captures \n, ensure string is trimmed

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function(options) {
     // The first result is the entire match, the second is only the version string
     versionRegEx = new RegExp('@' + key + ' ([^ ]*)', 'i');
     version = contents.match(versionRegEx)[1];
+    version = version.trim()
     // Break up the file name to splice in our version
     components = file.relative.split('.');
 


### PR DESCRIPTION
I was getting a 1.2.3?.filename, tracked it down to a newline right after @version 1.2.3\n. Apparently it was being captured as well.

Solution: Trim the string. 